### PR TITLE
[Feat] 일정 상세 조회에서 파일 다운로드 기능 추가 #29

### DIFF
--- a/src/components/layout/AppHeader.vue
+++ b/src/components/layout/AppHeader.vue
@@ -82,12 +82,12 @@ export default {
         } else {
           searchStore.setResults([]);
         }
-        // 검색 이후 검색 결과 페이지로 이동함
-        this.$router.push({name: "Search"});
       } catch (error) {
         console.error("Error occurred when searching events: ", error);
         searchStore.setResults([]);
       }
+      // 검색 이후 항상 검색 결과 페이지로 이동함
+      this.$router.push({name: "Search"});
     },
   },
 };

--- a/src/pages/search/EventDetail.vue
+++ b/src/pages/search/EventDetail.vue
@@ -15,41 +15,41 @@
           <v-col cols="12" md="10">
             <input type="datetime-local" :value="endDate" readonly>
           </v-col>
-          <v-col cols="12" md="2">
+          <!-- 장소 조회 -->
+          <v-col cols="12" md="2" v-if="place">
             <v-icon class="mr-2">mdi-map-marker</v-icon>
           </v-col>
-          <v-col cols="12" md="10">
+          <v-col cols="12" md="10" v-if="place">
             <input type="text" :value="place" readonly>
           </v-col>
+          <!-- 아이젠하워 매트릭스 조회 -->
           <v-col cols="12" md="2">
             <v-icon class="mr-2">mdi-alert-circle-outline</v-icon>
           </v-col>
           <v-col cols="12" md="10">
             <input type="text" :value="matrix" readonly>
           </v-col>
-          <v-col cols="12" md="2">
+          <!-- 알람 조회 -->
+          <v-col cols="12" md="2" v-if="displayAlarmInfo">
             <v-icon class="mr-2">mdi-bell-outline</v-icon>
           </v-col>
-          <v-col cols="12" md="10">
+          <v-col cols="12" md="10" v-if="displayAlarmInfo">
             <p v-html="displayAlarmInfo"></p>
           </v-col>
-          <v-col cols="12" md="2">
+          <!-- 메모 조회 -->
+          <v-col cols="12" md="2" v-if="memo">
             <v-icon class="mr-2">mdi-format-align-left</v-icon>
           </v-col>
-          <v-col cols="12" md="10">
+          <v-col cols="12" md="10" v-if="memo">
             <v-textarea :value="memo" variant="solo-filled" readonly auto-grow></v-textarea>
           </v-col>
-<!--          <v-col cols="12" md="12">-->
-<!--            &lt;!&ndash; 파일 목록은 보여주되, 다운로드 링크나 뷰어를 제공할 수 있습니다. &ndash;&gt;-->
-<!--            &lt;!&ndash; <v-subheader>첨부 파일</v-subheader> &ndash;&gt;-->
-<!--            <v-list dense>-->
-<!--              <v-list-item v-for="file in files" :key="file.name">-->
-<!--                &lt;!&ndash; <v-list-item-content>-->
-<!--                  <v-list-item-title>{{ file.name }}</v-list-item-title>-->
-<!--                </v-list-item-content> &ndash;&gt;-->
-<!--              </v-list-item>-->
-<!--            </v-list>-->
-<!--          </v-col>-->
+          <!-- 파일 다운로드 -->
+          <v-col cols="12" md="2" v-if="fileUrl">
+            <v-icon class="mr-2">mdi-file-multiple-outline</v-icon>
+          </v-col>
+          <v-col cols="12" md="10" v-if="fileUrl">
+            <v-btn :href="fileUrl" download>파일 다운로드</v-btn>
+          </v-col>
         </v-row>
       </v-card-text>
       <v-card-actions>
@@ -69,9 +69,14 @@ export default {
     return {
       dialog: false,
       title: '',
+      startDate: '',
+      endDate: '',
+      place: '',
+      matrix: '',
       memo: '',
       alarmInfo: '',
       displayAlarmInfo: '',
+      fileUrl: '',
     };
   },
   methods: {

--- a/src/pages/search/SearchResults.vue
+++ b/src/pages/search/SearchResults.vue
@@ -27,7 +27,7 @@
               />
             </v-list>
           </template>
-<!--          <v-text-field>{{result}}</v-text-field>-->
+          <v-text-field>{{result}}</v-text-field>
         </v-card>
       </v-col>
     </v-row>


### PR DESCRIPTION
## #️⃣연관된 이슈
- #29 

## 📝작업한 내용

### 파일 다운로드

- 일정 검색 후 일정 상세 조회 시 파일 다운로드를 가능하게 함
- 만약 파일이 없다면 파일 조회 행 자체가 생성되지 않음
- 장소, 알람, 메모 또한 필수가 아니기 때문에 해당 데이터가 없다면 조회 시 나오지 않도록 설정

**파일이 없는 경우**

![image](https://github.com/HanHwa-Team1-Final-Project/MOIM-FE/assets/27791880/5466c8b8-5a17-4445-9c76-fc3eb11b28e7)

**파일이 있는 경우**

![image](https://github.com/HanHwa-Team1-Final-Project/MOIM-FE/assets/27791880/de51c4dd-ab78-4369-97af-47ba1ecc7e61)

- 첨부된 파일이 잘 다운로드 되는 것도 확인함

<br/>

### 검색 결과 페이지 관련 오류

**AS-IS**

- 검색 결과 페이지로 넘어가지 않은 상태(헤더바에서 최초 검색 시도)에서 없는 데이터를 검색하면 검색 결과 페이지로 이동하지 못함

**TO-BE**

- 없는 데이터를 최초로 검색해도 검색 결과 페이지로 이동해서 "검색 결과가 없습니다."라는 메시지를 확인할 수 있음.

![image](https://github.com/HanHwa-Team1-Final-Project/MOIM-FE/assets/27791880/b3911e1c-4754-486a-9500-219df83fd308)

## PR 종류
> 어떤 종류의 PR인지 아래 항목 중에 체크
- [x] 버그 수정
- [x] 기능 추가

## 💬리뷰 요구사항(선택)

- 첨부 파일의 이름 그대로 다운로드할 수 있도록 처리해보려고 시도했으나 실패했음.
- 첨부한 파일의 이름을 다운로드할 파일의 이름으로 화면에 보여주고, 실제 다운로드할 때도 해당 이름 그대로 다운로드될 수 있도록 하려면 어떻게 해야 할지 잘 모르겠어요...😢

<br/>

- close #29