### PR TITLE
[Feat/Auth] 구글, 카카오 로그인 연동 / 로그아웃 구현

### DIFF
--- a/src/components/Oauth2Redirect.vue
+++ b/src/components/Oauth2Redirect.vue
@@ -1,42 +1,23 @@
 <template>
-    <div>
-    </div>
+  <div></div>
 </template>
 
 <script>
-// import axios from 'axios';
-import { jwtDecode } from 'jwt-decode';
-
-
 export default {
-    created(){
-        console.log(this.$route.query);
-        const accessToken = this.$route.query.accessToken;
-        const refreshToken = this.$route.query.refreshToken;
-        if (accessToken && refreshToken){
-            localStorage.setItem('accessToken', accessToken);
-            localStorage.setItem('refreshToken', refreshToken);
-            const decodedAccessToken = jwtDecode(accessToken);
-            localStorage.setItem('expiredTime', decodedAccessToken.exp);
-            this.$router.push({ name: 'MainPage'});
-        } else {
-            window.alert("로그인에 실패하였습니다.");
-        }
-    },
-    mounted(){
-        // URL에서 인증 코드 추출
-        const urlParams = new URLSearchParams(window.location.search);
-        const authCode = urlParams.get('code');
-        console.log(authCode);
-        
-        // if (authCode){
-        //     // axios를 사용하여 백엔드에 인증 코드 전달
-        //     axios.post(`${process.env.APP}/auth/google`)
-        // }
+  created() {
+    console.log("OAuth 리다이렉트 페이지 진입!");
+    console.log(this.$route.query);
+    const accessToken = this.$route.query.accessToken;
+    const refreshToken = this.$route.query.refreshToken;
+    if (accessToken && refreshToken) {
+      localStorage.setItem("accessToken", accessToken);
+      localStorage.setItem("refreshToken", refreshToken);
+      this.$router.push({ name: "MainPage" });
+    } else {
+      window.alert("로그인에 실패하였습니다.");
     }
-}
+  },
+};
 </script>
 
-<style lang="scss" scoped>
-
-</style>
+<style lang="scss" scoped></style>

--- a/src/pages/myPage/MyPageDialog.vue
+++ b/src/pages/myPage/MyPageDialog.vue
@@ -17,7 +17,6 @@
 
           <v-col cols="12" md="2"><h4>닉네임</h4></v-col>
           <v-col cols="12" md="10">
-            
             <input type="text" :value="nickname" readonly />
           </v-col>
 
@@ -29,6 +28,9 @@
       </v-card-text>
       <v-card-actions>
         <v-spacer></v-spacer>
+        <v-btn color="red darken-1" v-if="isLoggedIn" @click="logout"
+          >로그아웃</v-btn
+        >
         <v-btn color="blue darken-1" @click="closeDialog">닫기</v-btn>
       </v-card-actions>
     </v-card>
@@ -50,6 +52,15 @@ export default {
       isEditing: false,
       updateUserData: "",
     };
+  },
+  computed: {
+    // 로그인 상태 확인
+    isLoggedIn() {
+      return (
+        localStorage.getItem("accessToken") &&
+        localStorage.getItem("refreshToken")
+      );
+    },
   },
   mounted() {
     this.getUserData();
@@ -98,6 +109,12 @@ export default {
         console.error("Error fetching user data:", error);
       }
     },
+
+    logout() {
+      localStorage.removeItem("accessToken");
+      localStorage.removeItem("refreshToken");
+      this.$router.push({ name: "login" });
+    },
     // handleFileUpload(event) {
     //   const file = event.target.files[0];
     //   this.editableProfileImage = URL.createObjectURL(file);
@@ -109,7 +126,7 @@ export default {
     //     updateUserData.append("profileImage", this.editableProfileImage);
     //   }
     //   console.log("수정된 nickname", this.editableNickname);
-      
+
     //   console.log("수정된 파일", this.editableProfileImage);
 
     //   const authToken = localStorage.getItem("accessToken");

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -133,6 +133,9 @@ export default {
     googleLogin() {
       window.location.href = `${process.env.VUE_APP_API_BASE_URL}/oauth2/authorization/google?redirect_uri=http://localhost:8081/oauth2/redirect`;
     },
+    kakaoLogin() {
+      window.location.href = `${process.env.VUE_APP_API_BASE_URL}/oauth2/authorization/kakao?redirect_uri=http://localhost:8081/oauth2/redirect`;
+    },
   },
 };
 </script>


### PR DESCRIPTION
## #️⃣연관된 이슈
* #75 

## 📝작업한 내용
1. 소셜 로그인 성공 시 LocalStorage에 Access/Refresh Token 저장 후 main 페이지로 리다이렉트
2. 로그아웃 기능 구현

## PR 종류
> 어떤 종류의 PR인지 아래 항목 중에 체크
- [x] 버그 수정
- [x] 기능 추가