### PR TITLE
[Fix & Feat] 자동 스크롤 구현, 채팅리스트 이슈 수정, 디자인 수정 

### DIFF
--- a/src/pages/chat/ChatPage.vue
+++ b/src/pages/chat/ChatPage.vue
@@ -39,19 +39,19 @@
         </v-col>
       </v-sheet>
     </v-main>
-    <div style="width: 100%; margin-top: -2%;" class="input-container">
+    <div style="width: 100%; margin-top: -1%;" class="input-container">
       <v-row no-gutters align="center">
         <v-col>
           <v-text-field
               v-model="message"
               placeholder="메시지 입력..."
+              color="#0aca08"
+              density="comfortable"
               @keyup.enter="sendMessage"
               variant="outlined"
               hide-details
               rounded="pill"
-              class="input-message"
-          >
-          </v-text-field>
+              class="input-message"/>
         </v-col>
       </v-row>
     </div>

--- a/src/pages/chat/ChatPage.vue
+++ b/src/pages/chat/ChatPage.vue
@@ -2,18 +2,18 @@
   <v-app>
     <v-main style="overflow:auto; height: calc(100vh - 27vh);">
       <v-sheet>
-        <v-col style="padding-left:30px; padding-right: 30px; max-height: 69vh; overflow: auto;">
+        <v-col id="messageContainer" style="padding-left:30px; padding-right: 30px; max-height: 69vh; overflow: auto;">
           <div v-for="(responseObject, id) in messages" :key="id"
                :class="['d-flex flex-row align-center my-3', responseObject.nickname === nickname ? 'justify-end': null]">
 
             <!-- 로그인한 유저의 말풍선 -->
             <v-row v-if="responseObject.nickname === nickname" class="justify-end" style="max-width: 80%;">
               <v-col class="d-flex flex-row-reverse align-end">
-                <v-card class="pa-3" color="primary">
+                <v-card class="pa-3 logined-user-chat-bubble">
                   {{ responseObject.content }}
                 </v-card>
                 <v-sheet style="min-width: 70px;">
-                  {{formatTime(responseObject.createdAt)}}
+                  {{ formatTime(responseObject.createdAt) }}
                 </v-sheet>
               </v-col>
             </v-row>
@@ -26,7 +26,7 @@
               <v-col class="d-flex flex-column">
                 <v-sheet class="opponent-nickname mb-2">{{ responseObject.nickname }}</v-sheet>
                 <v-sheet class="d-flex flex-row align-end">
-                  <v-card class="pa-3 message" color="secondary">
+                  <v-card class="pa-3 opponent-chat-bubble">
                     {{ responseObject.content }}
                   </v-card>
                   <v-sheet style="margin-left: 10px; min-width: 70px;">
@@ -106,7 +106,7 @@ export default {
     console.log("로그인한 사용자의 닉네임: ", this.nickname);
     console.log("채팅 잘 넘어왔나 보자!!: ", this.initialMessages);
 
-    if(this.initialMessages && this.initialMessages.length) {
+    if (this.initialMessages && this.initialMessages.length) {
       this.messages = [...this.initialMessages];
       console.log("채팅 담겼나? ", this.messages);
     }
@@ -124,6 +124,7 @@ export default {
       this.messages = [...this.initialMessages];
       console.log("채팅 데이터 불러오기 성공!");
     }
+    this.scrollToBottom();
   },
 
   beforeUnmount() {
@@ -131,6 +132,17 @@ export default {
   },
 
   methods: {
+    scrollToBottom() {
+      // 메시지 목록을 감싸는 컨테이너 찾기
+      const container = document.getElementById('messageContainer');
+      if (container) {
+        // 잠시 딜레이를 주고 스크롤을 최하단으로 이동
+        setTimeout(() => {
+          container.scrollTop = container.scrollHeight;
+        }, 100);
+      }
+    },
+
     initializeWebSocket() {
       if (this.stompClient && this.stompClient.connected) return;
 
@@ -149,6 +161,9 @@ export default {
           const responseObject = JSON.parse(response.body); // ChatResponse와 동일한 형식이다.
           console.log("responseObject 형식: ", responseObject);
           this.messages.push(responseObject);
+
+          // 새 메시지가 수신된 후 스크롤을 아래로 이동
+          this.scrollToBottom();
         })
       }, (error) => {
         console.error("WebSocket connection error: ", error)
@@ -165,6 +180,9 @@ export default {
         }
         this.stompClient.send("/pub/chat/" + this.selectedChatting.id, {}, JSON.stringify(messageData))
         this.message = ""
+
+        // 메시지를 보낸 후 스크롤을 아래로 이동
+        this.scrollToBottom();
       } else {
         console.error("Stomp connection is not established yet.")
       }
@@ -204,12 +222,25 @@ export default {
   padding: 0 20px;
 }
 
-.input-message .v-input__slot{
+.input-message .v-input__slot {
   padding: 0 20px;
 }
 
 .opponent-nickname {
-  font-weight: 400;
+  font-weight: 500;
   font-size: 18px;
+}
+
+.logined-user-chat-bubble {
+  color: white;
+  background-color: #00d06a;
+  font-size: 17px;
+  font-weight: 500;
+}
+
+.opponent-chat-bubble {
+  background-color: #ededee;
+  font-size: 17px;
+  font-weight: 500;
 }
 </style>

--- a/src/pages/chat/ChattingList.vue
+++ b/src/pages/chat/ChattingList.vue
@@ -8,7 +8,7 @@
       </v-row>
     </v-container>
 
-    <v-container v-else style="margin-top: -20%;">
+    <v-container v-else style="margin-top: -18%;">
       <v-row>
         <v-col cols="4">
           <v-row v-if="chattings.length > 0">

--- a/src/pages/chat/ChattingList.vue
+++ b/src/pages/chat/ChattingList.vue
@@ -17,9 +17,10 @@
                   class="mx-auto result-card"
                   :class="{'selected-chatting-card': selectedChatting && chatting.id === selectedChatting.id}"
                   :title="chatting.title"
-                  :subtitle="chatting.hostNickName + ', ' + membersNickname"
+                  :subtitle="chatting.hostNickName + ', ' + chatting.membersNickname"
                   max-width="800"
                   @click="onChattingClick(chatting)"
+                  elevation="3"
                   link
               >
                 <template v-slot:append>
@@ -28,7 +29,7 @@
                       class="result-card-time"
                       :class="{'selected-chatting-card': selectedChatting && chatting.id === selectedChatting.id}"
                   >
-                    <v-list-item title="채팅 종료일" :subtitle="chattingDeleteDateTime"/>
+                    <v-list-item title="채팅 종료일" :subtitle="chatting.chattingDeleteDateTime"/>
                   </v-list>
                 </template>
               </v-card>
@@ -45,22 +46,40 @@
         <!-- 채팅 페이지 -->
         <v-col cols="8">
           <v-card v-if="selectedChatting && !loadingChatHistory" class="chatting-card" style="height: 85vh">
-            <v-card-title style="background-color: #2b783b">
-              <v-row>
-                <v-col cols="10">
-                  {{ selectedChatting.title }}
-                </v-col>
-                <v-col cols="2">
-                  <v-btn icon="mdi-close" @click="selectedChatting = null"/>
-                </v-col>
-              </v-row>
+            <v-card-title class="d-flex align-center chatpage-header">
+              <v-btn
+                  icon="mdi-arrow-left"
+                  @click="selectedChatting = null"
+                  left
+                  density="compact"
+                  size="large"
+                  color="white"
+              />
+              <div class="d-flex justify-center align-center flex-grow-1 chatroom-title">
+                {{ selectedChatting.title }}
+              </div>
             </v-card-title>
             <v-card-text class="chatting-card-text">
               <ChatPage :selectedChatting="selectedChatting" :initialMessages="chatHistory || []"/>
             </v-card-text>
           </v-card>
-          <v-card v-else-if="loadingChatHistory">
-            <v-card-title>채팅 내역 불러오는 중...</v-card-title>
+          <v-card v-else-if="loadingChatHistory"
+                  class="chatting-card loading-card"
+                  style="height: 85vh"
+          >
+            <v-col>
+              <v-row justify="center">
+                <v-card-text class="loading-text">채팅 내역 불러오는 중</v-card-text>
+              </v-row>
+              <v-row justify="center">
+                <v-progress-circular
+                    color="#00d06a"
+                    indeterminate
+                    :size="40"
+                    :width="6"
+                ></v-progress-circular>
+              </v-row>
+            </v-col>
           </v-card>
         </v-col>
       </v-row>
@@ -101,8 +120,6 @@ export default {
       this.selectedChatting = chatting;
       this.setChattingInfo(chatting);
       this.loadingChatHistory = true;
-
-      // this.messages = [];
       this.fetchChatHistory(chatting.id)
           .finally(() => {
             this.loadingChatHistory = false;
@@ -120,8 +137,8 @@ export default {
         minute: "2-digit",
         hour12: true,
       };
-      this.chattingDeleteDateTime = date.toLocaleString("ko-KR", options);
-      this.membersNickname = chatting.memberRooms.map(memberRooms => memberRooms[1]).join(', ');
+      chatting.chattingDeleteDateTime = date.toLocaleString("ko-KR", options);
+      chatting.membersNickname = chatting.memberRooms.map(memberRooms => memberRooms[1]).join(', ');
     },
 
     // 채팅방 별 채팅 내역 불러오기
@@ -169,11 +186,10 @@ export default {
           this.currentPage = page;
           await this.checkNextPage(page + 1);
 
-          if (this.chattings.length > 0) {
-            const firstChatRoom = this.chattings[0];
-            this.setChattingInfo(firstChatRoom);
-            this.selectedChatting = null;
-          }
+          // 모든 채팅방에 대해 참여자 닉네임과 채팅 종료일을 세팅한다.
+          this.chattings.forEach(chatting => this.setChattingInfo(chatting));
+
+          this.selectedChatting = null;
         }
       } catch (error) {
         console.error("Error fetching chattings:", error);
@@ -267,7 +283,6 @@ export default {
 .chatting-card {
   height: 80vh;
   overflow: hidden;
-
 }
 
 .chatting-card-text {
@@ -276,10 +291,40 @@ export default {
 }
 
 .result-card {
-  background-color: #f8d7da;
   padding-top: 0 !important;
   padding-bottom: 0 !important;
   margin-top: 0 !important;
+  border: 1px solid rgba(34, 173, 157, 0.14);
+}
+
+.chatpage-header {
+  background: linear-gradient(
+      90deg,
+      #00d06a,
+      #06c7ba
+  ); /* 그라데이션 배경 적용 */
+  background-size: 100%; /* 그라데이션 정도*/
+}
+
+.chatroom-title {
+  color: white;
+  font-weight: 800;
+  font-size: 20px;
+}
+
+.loading-card {
+  flex-grow: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+}
+
+.loading-text {
+  font-size: 25px;
+  font-weight: 700;
+  color: rgba(54, 54, 54, 0.86);
+  padding: 30px;
 }
 
 .participant-info {


### PR DESCRIPTION
## 📝작업한 내용

### 자동 스크롤
- 채팅을 입력했을 때 가장 최신 메시지가 있는 곳으로 이동할 수 있게 수정
- 채팅방 진입 시 가장 최신 메시지가 있는 곳으로 이동

### 채팅방 리스트 이슈 수정
- 채팅방 리스트에 참여자 닉네임과 종료일을 제대로 업데이트하지 못하는 문제를 수정
  - 최초에 페이지 로딩 시 setChattingInfo 메서드를 호출하여 가장 첫 번째 채팅방에 대한 정보만 세팅하는 것을 수정.
  - 페이지가 로딩되면서 채팅방 목록을 가져오는 fetchChattings() 메서드에서 반환받은 모든 채팅방들에 대해 setChattingInfo()를 호출한다.

### 디자인 수정
- 채팅 목록을 불러올 때 시간이 오래 걸리면 v-progress-circular로 로딩 중임을 표시
- 채팅 목록 한 페이지에 7개 데이터가 나오도록 수정
- 채팅 헤더바의 디자인 수정
- 말풍선 박스 색상 수정

## PR 종류
> 어떤 종류의 PR인지 아래 항목 중에 체크
- [x] 버그 수정
- [x] 기능 추가