### PR TITLE
[Fix] 로그인 화면 리다이렉팅 문제 해결

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -40,6 +40,14 @@ const routes = [
     {
         path: "/",
         redirect: '/main',
+        beforeEnter: (to, from, next) => {
+            const accessToken = localStorage.getItem('accessToken');
+            if (!accessToken) {
+                next('/login'); // accessToken이 없으면 /login으로 리다이렉트
+            } else {
+                next(); // accessToken이 있다면 리다이렉트 없이 현재 경로를 유지
+            }
+        },
         component: MainPage,
         children: [
             {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -65,10 +65,8 @@ const routes = [
                 name: "EisenhowerMatrix",
                 component: EisenhowerMatrix
             },
-
-            // 검색 결과
             {
-                path: "/search",
+                path: "search",
                 name: "Search",
                 component: SearchResults,
             },
@@ -82,7 +80,6 @@ const routes = [
                 name: "eventDetail",
                 component: EventDetailDialog
             },
-            // 일정 수정
             {
                 path: "updateEvent",
                 name: "updateEvent",


### PR DESCRIPTION
## 📝작업한 내용

**AS-IS**

- 최초에 accessToken이 없는 상태라면 localhost:8081로 진입했을 때 localhost:8081/login 화면으로 바로 가지 못하고, 한 번 localhost:8081/main으로 진입한 뒤 바로 localhost:8081/login으로 이동하는 문제가 있었음

**TO-BE**

- 최초에 accessToken이 없는 상태라면 localhost:8081로 진입했을 때 바로 localhost:8081/login으로 이동.
- 라우팅 정보를 담고 있는 index.js에서 beforeEnter 로직을 하나 추가해서 해결함.

```javascript
path: "/",
redirect: '/main',
beforeEnter: (to, from, next) => {
    const accessToken = localStorage.getItem('accessToken');
    if (!accessToken) {
        next('/login'); // accessToken이 없으면 /login으로 리다이렉트
    } else {
        next(); // accessToken이 있다면 리다이렉트 없이 현재 경로를 유지
    }
},
component: MainPage,
children: [

(생략...)
```

## PR 종류
> 어떤 종류의 PR인지 아래 항목 중에 체크
- [x] 버그 수정